### PR TITLE
Provide mariadb UID, GID and SMF project

### DIFF
--- a/include/project.mk
+++ b/include/project.mk
@@ -30,11 +30,16 @@ SMF_PROJECT.mysql-cluster=	mysql
 SMF_PROJECT.mysql-server=	mysql
 SMF_PROJECT.percona-cluster=	mysql
 SMF_PROJECT.percona-server=	mysql
-SMF_PROJECT.mariadb-server=	mysql
 SMF_PROJECT_ATTRS.mysql=	process.max-file-descriptor=(basic,15000,deny)
 SMF_PROJECT_DESC.mysql=		MySQL service
 SMF_PROJECT_GROUP.mysql=	${MYSQL_GROUP}
 SMF_PROJECT_USER.mysql=		${MYSQL_USER}
+
+SMF_PROJECT.mariadb-server=    mariadb
+SMF_PROJECT_ATTRS.mariadb=     process.max-file-descriptor=(basic,15000,deny)
+SMF_PROJECT_DESC.mariadb=      MariaDB service
+SMF_PROJECT_GROUP.mariadb=     ${MARIADB_GROUP}
+SMF_PROJECT_USER.mariadb=      ${MARIADB_USER}
 
 SMF_PROJECT.php53-fpm=		php
 SMF_PROJECT.php54-fpm=		php

--- a/include/users.mk
+++ b/include/users.mk
@@ -718,3 +718,6 @@ PKG_UID.tinydyn=	768
 #
 PKG_UID.ucspissl=	767
 PKG_GID.ucspissl=	767
+#
+PKG_UID.mariadb=	766
+PKG_GID.mariadb=	766


### PR DESCRIPTION
Based on the current SMF manifest [1] used for mariadb it's required to
add an extra UID and GID for the service. Additional the current SMF
manifest used for mariadb-server requires the project "mariadb" to be
created.

[1] https://github.com/joyent/pkgsrc/blob/joyent/release/trunk/databases/mariadb106-server/files/smf/manifest.xml#L13-L14